### PR TITLE
Possible implementation for social share 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5241,6 +5241,29 @@
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
+        "jsonp": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+            "integrity": "sha1-pltPoPEL2nGaBUQep7lMVfPhW64=",
+            "requires": {
+                "debug": "^2.1.3"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
         "jsonparse": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -8211,6 +8234,15 @@
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
             "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
+        },
+        "react-share": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/react-share/-/react-share-4.3.1.tgz",
+            "integrity": "sha512-ikh0y8NKxhU7dQBXh1Jccd1ANLb9WNYaSonln33yLyNYo2HTBRp9D6HkTsFlgX/2J9GPsGLqhzzpDNiVKx3WVA==",
+            "requires": {
+                "classnames": "^2.2.5",
+                "jsonp": "^0.2.1"
+            }
         },
         "react-transition-group": {
             "version": "4.4.1",
@@ -11221,4 +11253,3 @@
         }
     }
 }
-

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "react": "^17.0.1",
         "react-bootstrap": "^1.4.3",
         "react-dom": "^17.0.1",
+        "react-share": "^4.3.1",
         "url-loader": "^2.3.0",
         "validator": "^11.1.0",
         "woocommerce-api": "^1.5.0"

--- a/pages/product/[slug].js
+++ b/pages/product/[slug].js
@@ -2,14 +2,26 @@ import Layout from '../../src/components/layouts/Layout';
 import AddToCartButton from '../../src/components/cart/AddToCartButton';
 import client from '../../src/apollo/ApolloClient';
 import Image from '../../src/components/Image';
+import SocialShare from '../../src/components/social-share/SocialShare';
+
 import { 
     PRODUCT_QUERY,
     PRODUCT_SLUGS 
 } from '../../src/queries';
 
+import { useRouter } from 'next/router'
+
+
+
+
 const Product = ({data}) => {
 
     const { product } = data || {}
+
+    const router = useRouter();
+
+
+    const path = router.asPath; // url path: starts with backslash (/) 
 
     return (
         <Layout>
@@ -30,6 +42,7 @@ const Product = ({data}) => {
                                 </span>
                             </p>
                             <AddToCartButton product={product} />
+                           
                         </div>
                     </div>
                     <div className="product-container" key={product?.id}>
@@ -37,6 +50,7 @@ const Product = ({data}) => {
                             className="product-description"
                             dangerouslySetInnerHTML={{ __html: product?.description }}
                         />
+                         <SocialShare path={path} />
                     </div>
                 </div>
             ) : (

--- a/src/components/social-share/SocialShare.js
+++ b/src/components/social-share/SocialShare.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import config from '../../../client-config';
+
+import {
+    FacebookShareButton,
+    FacebookIcon,
+    TwitterShareButton,
+    TwitterIcon,
+    WhatsappShareButton,
+    WhatsappIcon
+} from "react-share";
+
+
+
+const SocialShare = ( { path } ) => {
+    
+    const { siteUrl }  = config;
+    const shareUrl = `${siteUrl}${path}`;
+
+    return (
+        <div className="social-share">
+            <FacebookShareButton url={shareUrl}>
+                <FacebookIcon size={32} round={true} />
+            </FacebookShareButton>
+            <TwitterShareButton url={shareUrl}> 
+                <TwitterIcon size={32} round={true} />
+            </TwitterShareButton>
+            <WhatsappShareButton url={shareUrl}>
+                <WhatsappIcon size={32} round={true} />
+            </WhatsappShareButton>
+        </div>
+    )
+}
+
+export default SocialShare


### PR DESCRIPTION
This is one possible implementation for social share buttons described in #61 

I used `react-share` library which looks solid and supported, building our own solution would be just a waste of time in my opinion as we gonna be building the same thing. 

After we create `wp-decoupled-helper` ( #59 ) plugin we will add options for user to choose which social sites to include and also which post types to display the share buttons in. 

